### PR TITLE
[Mellanox][asan] add address sanitizer support for syncd

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -429,9 +429,9 @@ start() {
 {%- endif %}
 {%- if docker_container_name == "swss" %}
         -e ASIC_VENDOR={{ sonic_asic_platform }} \
-{%- if enable_asan == "y" %}
-        -v /var/log/asan/:/var/log/asan \
 {%- endif -%}
+{%- if docker_container_name in ["swss", "syncd"] and enable_asan == "y" %}
+        -v /var/log/asan/:/var/log/asan \
 {%- endif -%}
 {%- if docker_container_name == "bgp" %}
         -v /etc/sonic/frr/$DEV:/etc/frr:rw \
@@ -493,7 +493,7 @@ stop() {
     {%- elif docker_container_name == "teamd" %}
     # Longer timeout of 60 sec to wait for Portchannels to be cleaned.
     /usr/local/bin/container stop -t 60 $DOCKERNAME
-    {%- elif docker_container_name == "swss" and enable_asan == "y" %}
+    {%- elif docker_container_name in ["swss", "syncd"] and enable_asan == "y" %}
     /usr/local/bin/container stop -t 60 $DOCKERNAME
     {%- else %}
     /usr/local/bin/container stop $DOCKERNAME

--- a/files/build_templates/sonic_version.yml.j2
+++ b/files/build_templates/sonic_version.yml.j2
@@ -23,4 +23,6 @@ built_by: {{ built_by }}
 {{ name }}: {{ version }}
 {% endfor -%}
 {% endif -%}
-
+{% if ENABLE_ASAN == "y" -%}
+asan: 'yes'
+{% endif -%}

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -31,6 +31,9 @@ RUN apt-get update && \
         libxml2     \
         python-pip  \
         python-dev \
+{%- if ENABLE_ASAN == "y" %}
+        libasan5 \
+{%- endif %}
         python-setuptools
 
 RUN pip2 install --upgrade pip
@@ -58,8 +61,12 @@ RUN apt-get clean -y && \
     apt-get autoremove -y && \
     rm -rf /debs
 
-COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
+COPY ["supervisord.conf.j2", "/usr/share/sonic/templates/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
+
+RUN mkdir -p /etc/supervisor/conf.d/
+RUN sonic-cfggen -a "{\"ENABLE_ASAN\":\"{{ENABLE_ASAN}}\"}" -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
+RUN rm -f /usr/share/sonic/templates/supervisord.conf.j2
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
@@ -37,3 +37,6 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
+{% if ENABLE_ASAN == "y" %}
+environment=ASAN_OPTIONS="log_path=/var/log/asan/syncd-asan.log"
+{% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support address sanitizer for Mellanox syncd
#### How I did it
* /var/log/asan is mapped for syncd container (the same as for swss)
* container stop() has a timeout (60s) for syncd (the same as for swss)
This is so libasan has enough time to generate a report.
* added ASAN's log path to Mellanox syncd supervisord.conf
* added "asan: yes" to sonic_version.yml
#### How to verify it
1) Added artificial memory leaks
2) Compiled with ENABLE_ASAN=y
3) Installed the image on DUT
4) Rebooted the DUT
5) Verified that /var/log/asan/syncd-asan.log contains the leaks
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

