### PR TITLE
[ci][asan] add docker-sonic-vs with ASAN build

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -30,6 +30,7 @@ jobs:
       BUILD_OPTIONS: ${{ parameters.buildOptions }}
       DOCKER_DATA_ROOT_FOR_MULTIARCH: /data/march/docker
       dbg_image: no
+      asan_image: no
       swi_image: no
       raw_image: no
       docker_syncd_rpc_image: no
@@ -42,6 +43,7 @@ jobs:
         - name: vs
           variables:
             dbg_image: yes
+            asan_image: yes
 
         - name: barefoot
           variables:
@@ -105,6 +107,10 @@ jobs:
             if [ $(dbg_image) == yes ]; then
               make $BUILD_OPTIONS INSTALL_DEBUG_TOOLS=y target/sonic-vs.img.gz
               mv target/sonic-vs.img.gz target/sonic-vs-dbg.img.gz
+            fi
+            if [ $(asan_image) == yes ]; then
+              make $BUILD_OPTIONS ENABLE_ASAN=y target/docker-sonic-vs.gz
+              mv target/docker-sonic-vs.gz target/docker-sonic-vs-asan.gz
             fi
             make $BUILD_OPTIONS target/docker-sonic-vs.gz target/sonic-vs.img.gz target/docker-ptf.gz
             if [ $(Build.Reason) != 'PullRequest' ];then


### PR DESCRIPTION
The asan-enabled docker image will be used in other CIs that run DVS
tests.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To add a possibility to run DVS tests with ASAN for other CIs (e.g. swss).
#### How I did it
Added the 'asan_image' flag to the vs job group.
#### How to verify it
Run the CI and check the docker-sonic-vs-asan.gz artifact.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

