### PR TITLE
[Mellanox][asan] disable fast_unwind_on_malloc for mlnx syncd

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
@@ -1,4 +1,4 @@
-{% set asan_extra_options = ':print_suppressions=0' %}
+{% set asan_extra_options = ':print_suppressions=0:fast_unwind_on_malloc=0' %}
 [supervisord]
 logfile_maxbytes=1MB
 logfile_backups=2


### PR DESCRIPTION
#### Why I did it
To improve ASAN backtrace output when the call stack contains a code that is not compiled with -fno-omit-frame-pointer.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added fast_unwind_on_malloc=0 to the ASAN_OPTIONS
#### How to verify it
Build and test docker-syncd-mlnx.gz with ENABLE_ASAN=y

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

