### PR TITLE
[build] add support for 2 stage rootfs build

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -568,6 +568,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            MIRROR_SNAPSHOT=$(MIRROR_SNAPSHOT) \
                            SONIC_VERSION_CONTROL_COMPONENTS=$(SONIC_VERSION_CONTROL_COMPONENTS) \
                            SONIC_OS_VERSION=$(SONIC_OS_VERSION) \
+                           ENABLE_RFS_SPLIT_BUILD=$(ENABLE_RFS_SPLIT_BUILD) \
                            $(SONIC_OVERRIDE_BUILD_VARS)
 
 .PHONY: sonic-slave-build sonic-slave-bash init reset

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -59,6 +59,9 @@ TRUSTED_GPG_DIR=$BUILD_TOOL_PATH/trusted.gpg.d
     exit 1
 }
 
+## Check if not a last stage of RFS build
+if [[ $RFS_SPLIT_LAST_STAGE != y ]]; then
+
 ## Prepare the file system directory
 if [[ -d $FILESYSTEM_ROOT ]]; then
     sudo rm -rf $FILESYSTEM_ROOT || die "Failed to clean chroot directory"
@@ -71,10 +74,12 @@ touch $FILESYSTEM_ROOT/$PLATFORM_DIR/firsttime
 ## ensure proc is mounted
 sudo mount proc /proc -t proc || true
 
-## make / as a mountpoint in chroot env, needed by dockerd
-pushd $FILESYSTEM_ROOT
-sudo mount --bind . .
-popd
+if [[ $ENABLE_RFS_SPLIT_BUILD != y ]]; then
+    ## make / as a mountpoint in chroot env, needed by dockerd
+    pushd $FILESYSTEM_ROOT
+    sudo mount --bind . .
+    popd
+fi
 
 ## Build the host debian base system
 echo '[INFO] Build host debian base system...'
@@ -615,6 +620,46 @@ if [[ ! -f './asic_config_checksum' ]]; then
     exit 1
 fi
 sudo cp ./asic_config_checksum $FILESYSTEM_ROOT/etc/sonic/asic_config_checksum
+
+## Check if not a last stage of RFS build
+fi
+
+if [[ $RFS_SPLIT_FIRST_STAGE == y ]]; then
+    echo '[INFO] Finished with RFS first stage'
+    echo '[INFO] Umount all'
+
+    ## Display all process details access /proc
+    sudo LANG=C chroot $FILESYSTEM_ROOT fuser -vm /proc
+    ## Kill the processes
+    sudo LANG=C chroot $FILESYSTEM_ROOT fuser -km /proc || true
+    ## Wait fuser fully kill the processes
+    sleep 15
+    sudo LANG=C chroot $FILESYSTEM_ROOT umount /proc
+
+    sudo rm -f $TARGET_PATH/$RFS_SQUASHFS_NAME
+    sudo mksquashfs $FILESYSTEM_ROOT $TARGET_PATH/$RFS_SQUASHFS_NAME
+
+    exit 0
+fi
+
+if [[ $RFS_SPLIT_LAST_STAGE == y ]]; then
+    echo '[INFO] RFS build: second stage'
+
+    ## ensure proc is mounted
+    sudo mount proc /proc -t proc || true
+
+    sudo fuser -vm $FILESYSTEM_ROOT || true
+    sudo rm -rf $FILESYSTEM_ROOT
+    sudo unsquashfs -d $FILESYSTEM_ROOT $TARGET_PATH/$RFS_SQUASHFS_NAME
+
+    ## make / as a mountpoint in chroot env, needed by dockerd
+    pushd $FILESYSTEM_ROOT
+    sudo mount --bind . .
+    popd
+
+    trap_push 'sudo LANG=C chroot $FILESYSTEM_ROOT umount /proc || true'
+    sudo LANG=C chroot $FILESYSTEM_ROOT mount proc /proc -t proc
+fi
 
 if [ -f sonic_debian_extension.sh ]; then
     ./sonic_debian_extension.sh $FILESYSTEM_ROOT $PLATFORM_DIR $IMAGE_DISTRO

--- a/rules/config
+++ b/rules/config
@@ -300,3 +300,6 @@ GZ_COMPRESS_PROGRAM ?= gzip
 
 # SONIC_OS_VERSION - sonic os version
 SONIC_OS_VERSION ?= 11
+
+# ENABLE_RFS_SPLIT - enable 2-stage installer build
+ENABLE_RFS_SPLIT_BUILD ?= n

--- a/slave.mk
+++ b/slave.mk
@@ -90,6 +90,7 @@ export BUILD_WORKDIR
 export GZ_COMPRESS_PROGRAM
 export MIRROR_SNAPSHOT
 export SONIC_OS_VERSION
+export ENABLE_RFS_SPLIT_BUILD
 
 ###############################################################################
 ## Utility rules
@@ -442,6 +443,7 @@ $(info "BUILD_MULTIASIC_KVM"             : "$(BUILD_MULTIASIC_KVM)")
 endif
 $(info "CROSS_BUILD_ENVIRON"             : "$(CROSS_BUILD_ENVIRON)")
 $(info "GZ_COMPRESS_PROGRAM"             : "$(GZ_COMPRESS_PROGRAM)")
+$(info "ENABLE_RFS_SPLIT_BUILD"          : "$(ENABLE_RFS_SPLIT_BUILD)")
 $(info )
 else
 $(info SONiC Build System for $(CONFIGURED_PLATFORM):$(CONFIGURED_ARCH))
@@ -1208,6 +1210,60 @@ $(DOCKER_LOAD_TARGETS) : $(TARGET_PATH)/%.gz-load : .platform docker-start $$(TA
 ## Installers
 ###############################################################################
 
+ifeq ($(ENABLE_RFS_SPLIT_BUILD),y)
+define rfs_get_installer_dependencies
+$(1)__$($(1)_MACHINE)__rfs.squashfs $(if $($(1)_DEPENDENT_MACHINE),$(1)__$($(1)_DEPENDENT_MACHINE)__rfs.squashfs)
+endef
+
+$(foreach installer, $(SONIC_INSTALLERS), $(eval $(installer)_RFS_DEPENDS=$(call rfs_get_installer_dependencies,$(installer))))
+
+SONIC_RFS_TARGETS= $(foreach installer, $(SONIC_INSTALLERS), $(call rfs_get_installer_dependencies,$(installer)))
+SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS))
+endif
+
+$(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
+        .platform \
+        build_debian.sh \
+        $(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_KERNEL))
+	$(HEADER)
+
+	$(eval installer=$(word 1,$(subst __, ,$*)))
+	$(eval machine=$(word 2,$(subst __, ,$*)))
+
+	export debs_path="$(IMAGE_DISTRO_DEBS_PATH)"
+	export initramfs_tools="$(IMAGE_DISTRO_DEBS_PATH)/$(INITRAMFS_TOOLS)"
+	export linux_kernel="$(IMAGE_DISTRO_DEBS_PATH)/$(LINUX_KERNEL)"
+	export kversion="$(KVERSION)"
+	export image_type="$($(installer)_IMAGE_TYPE)"
+	export sonicadmin_user="$(USERNAME)"
+	export sonic_asic_platform="$(patsubst %-$(CONFIGURED_ARCH),%,$(CONFIGURED_PLATFORM))"
+	export RFS_SPLIT_FIRST_STAGE=y
+
+	j2 -f env files/initramfs-tools/union-mount.j2 onie-image.conf > files/initramfs-tools/union-mount
+	j2 -f env files/initramfs-tools/arista-convertfs.j2 onie-image.conf > files/initramfs-tools/arista-convertfs
+
+	RFS_SQUASHFS_NAME=$* \
+	USERNAME="$(USERNAME)" \
+	PASSWORD="$(PASSWORD)" \
+	CHANGE_DEFAULT_PASSWORD="$(CHANGE_DEFAULT_PASSWORD)" \
+	TARGET_MACHINE=$(machine) \
+	IMAGE_TYPE=$($(installer)_IMAGE_TYPE) \
+	TARGET_PATH=$(TARGET_PATH) \
+	TRUSTED_GPG_URLS=$(TRUSTED_GPG_URLS) \
+	SONIC_ENABLE_SECUREBOOT_SIGNATURE="$(SONIC_ENABLE_SECUREBOOT_SIGNATURE)" \
+	SIGNING_KEY="$(SIGNING_KEY)" \
+	SIGNING_CERT="$(SIGNING_CERT)" \
+	PACKAGE_URL_PREFIX=$(PACKAGE_URL_PREFIX) \
+	DBGOPT='$(DBGOPT)' \
+	SONIC_VERSION_CACHE=$(SONIC_VERSION_CACHE) \
+	MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) \
+	CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) \
+	MASTER_KUBERNETES_VERSION=$(MASTER_KUBERNETES_VERSION) \
+	MASTER_CRI_DOCKERD=$(MASTER_CRI_DOCKERD) \
+		./build_debian.sh $(LOG)
+
+	$(FOOTER)
+
 # targets for building installers with base image
 $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
         .platform \
@@ -1262,7 +1318,9 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
         $(addprefix $(FILES_PATH)/,$($(SONIC_CTRMGRD)_FILES)) \
         $(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_YANG_MGMT_PY3)) \
         $(addprefix $(PYTHON_WHEELS_PATH)/,$(SYSTEM_HEALTH)) \
-        $(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_HOST_SERVICES_PY3))
+        $(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_HOST_SERVICES_PY3)) \
+        $(if $(findstring y,$(ENABLE_RFS_SPLIT_BUILD)),$$(addprefix $(TARGET_PATH)/,$$($$*_RFS_DEPENDS)))
+
 	$(HEADER)
 	# Pass initramfs and linux kernel explicitly. They are used for all platforms
 	export debs_path="$(IMAGE_DISTRO_DEBS_PATH)"
@@ -1417,6 +1475,9 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		chmod +x sonic_debian_extension.sh,
 	)
 
+	export RFS_SPLIT_FIRST_STAGE=n
+	export RFS_SPLIT_LAST_STAGE="$(ENABLE_RFS_SPLIT_BUILD)"
+
 	# Build images for the MACHINE, DEPENDENT_MACHINE defined.
 	$(foreach dep_machine, $($*_MACHINE) $($*_DEPENDENT_MACHINE), \
 		DEBUG_IMG="$(INSTALL_DEBUG_TOOLS)" \
@@ -1424,6 +1485,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		DEBUG_SRC_ARCHIVE_FILE="$(DBG_SRC_ARCHIVE_FILE)" \
 			scripts/dbg_files.sh
 
+		RFS_SQUASHFS_NAME=$*__$(dep_machine)__rfs.squashfs \
 		DEBUG_IMG="$(INSTALL_DEBUG_TOOLS)" \
 		DEBUG_SRC_ARCHIVE_FILE="$(DBG_SRC_ARCHIVE_FILE)" \
 		USERNAME="$(USERNAME)" \


### PR DESCRIPTION
PoC for rootfs 2-stage build
#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

