### PR TITLE
[vs] support for ARM build

### DIFF
--- a/platform/vs/syncd-vs.mk
+++ b/platform/vs/syncd-vs.mk
@@ -1,10 +1,10 @@
 $(LIBSAIREDIS)_DPKG_TARGET = binary-syncd-vs
 
-SYNCD_VS = syncd-vs_1.0.0_amd64.deb
+SYNCD_VS = syncd-vs_1.0.0_$(CONFIGURED_ARCH).deb
 $(SYNCD_VS)_RDEPENDS += $(LIBSAIREDIS) $(LIBSAIMETADATA) $(LIBSAIVS)
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(SYNCD_VS)))
 
-SYNCD_VS_DBG = syncd-vs-dbg_1.0.0_amd64.deb
+SYNCD_VS_DBG = syncd-vs-dbg_1.0.0_$(CONFIGURED_ARCH).deb
 $(SYNCD_VS_DBG)_DEPENDS += $(SYNCD_VS)
 $(SYNCD_VS_DBG)_RDEPENDS += $(SYNCD_VS)
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(SYNCD_VS_DBG)))


### PR DESCRIPTION
#### Why I did it
To support the building of ARM-based docker-sonic-vs.gz
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fixed SYNCD_VS build rule to be architecture-specific.
#### How to verify it
make configure PLATFORM=vs PLATFORM_ARCH=arm64
make target/docker-sonic-vs.gz

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

