### PR TITLE
[build] add SKIP_BUILD_HOOK support for curl

### DIFF
--- a/src/sonic-build-hooks/hooks/curl
+++ b/src/sonic-build-hooks/hooks/curl
@@ -3,4 +3,9 @@
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
 [ -z $REAL_COMMAND ] && REAL_COMMAND=/usr/bin/curl
 
+if [ "$SKIP_BUILD_HOOK" == y ]; then
+    $REAL_COMMAND "$@"
+    exit $?
+fi
+
 REAL_COMMAND=$REAL_COMMAND download_packages "$@"


### PR DESCRIPTION
#### Why I did it
To support SKIP_BUILD_HOOK for curl command so the targets downloaded by curl (SONIC_ONLINE_DEBS, SONIC_ONLINE_FILES) can utilize it.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add a logic to invoke a real command instead of a `download_packages()` (the same way it's done for wget)
#### How to verify it
Add an online target (with URL attribute).
Add the "SKIP_VERSION=y" to this target.
Check that download_packages is not invoked.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

