### PR TITLE
[Mellanox] update platform name for simx platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "MSN4700",
+        "name": "MSN4700_SIMX",
         "components": [
             {
                 "name": "ONIE"

--- a/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "SN4280",
+        "name": "SN4280_SIMX",
         "components": [
             {
                 "name": "ONIE"

--- a/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "SN5400",
+        "name": "SN5400_SIMX",
         "components": [
             {
                 "name": "ONIE"

--- a/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "SN5600",
+        "name": "SN5600_SIMX",
         "components": [
             {
                 "name": "ONIE"


### PR DESCRIPTION
#### Why I did it
To update Mellanox simx platforms chassis name

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated relevant platform.json files

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

