### PR TITLE
[nvidia-bluefield] update platform-api thermal logic

### DIFF
--- a/platform/nvidia-bluefield/platform-api/sonic_platform/thermal_bf3.py
+++ b/platform/nvidia-bluefield/platform-api/sonic_platform/thermal_bf3.py
@@ -18,7 +18,11 @@
 try:
     from sonic_platform_base.thermal_base import ThermalBase
     from sonic_py_common.logger import Logger
+    from .device_data import DeviceDataManager
+    from enum import Enum, auto
     import os
+    import json
+    import subprocess
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -26,28 +30,75 @@ except ImportError as e:
 logger = Logger()
 
 MLXBF_BASE_PATH = '/sys/kernel/debug/mlxbf-ptm/monitors/status'
+SSD_DEV='nvme0'
 
-SENSORS = [
-    {'name': 'CPU', 'mlxbf_sensor_name': 'core_temp', 'ht': 95, 'cht': 100},
-    {'name': 'DDR', 'mlxbf_sensor_name': 'ddr_temp', 'ht': 95, 'cht': 100},
-    {'name': 'SFP0', 'iface': 'Ethernet0', 'hwmon_path': None},
-    {'name': 'SFP1', 'iface': 'Ethernet4', 'hwmon_path': None},
+class ThermalType(Enum):
+    MLXBF = auto()
+    SFP = auto()
+    SSD = auto()
+
+MLXBF_SENSORS = [
+    {'name': 'CPU', 'thermal_type': ThermalType.MLXBF, 'mlxbf_sensor_name': 'core_temp', 'ht': 95, 'cht': 100},
+    {'name': 'DDR', 'thermal_type': ThermalType.MLXBF, 'mlxbf_sensor_name': 'ddr_temp', 'ht': 95, 'cht': 100},
 ]
 
-def set_hwmon_path(sensor):
-    base = f'/sys/class/net/{sensor["iface"]}/device/hwmon'
+def get_hwmon_path(iface):
+    base = f'/sys/class/net/{iface}/device/hwmon'
     dirs = os.listdir(base)
     if len(dirs) != 1 or not dirs[0].startswith('hwmon'):
-        logger.log_error(f'Failed to find hwmon path for {sensor["iface"]}')
+        logger.log_error(f'Failed to find hwmon path for {iface}')
         return
-    sensor['hwmon_path'] = f'{base}/{dirs[0]}'
+    return f'{base}/{dirs[0]}'
+
+def initialize_sfp_thermals():
+    sfps = []
+    sfp_count = DeviceDataManager().get_sfp_count()
+    for i in range(sfp_count):
+        iface = f'Ethernet{i * 4}'
+        sfp_thermal = Thermal(name=f'SFP{i}', thermal_type=ThermalType.SFP, hwmon_path=get_hwmon_path(iface))
+        sfps.append(sfp_thermal)
+    return sfps
+
+def read_smartctl(dev, all=False):
+    all_flag = 'u' if all else ''
+    cmd = f'smartctl -x /dev/{dev} --json=v{all_flag}'
+    try:
+        output = subprocess.check_output(cmd.split(' ')).decode().strip()
+        return json.loads(output)
+    except:
+        logger.log_error('Failed to read smartctl output')
+        return {}
+
+def read_ssd_temperatrue(dev):
+    try:
+        return int(read_smartctl(dev)['temperature']['current'])
+    except:
+        logger.log_error('Failed to read nvme0 temperature')
+        return 'N/A'
+
+def read_ssd_thresholds(dev):
+    higt_th = None
+    crit_th = None
+    def parse_value(v):
+        return int(v.split(':')[1].strip().split(' ')[0])
+
+    output = read_smartctl(dev, all=True)
+    for k,v in output.items():
+        if "smartctl" in k:
+            if not higt_th and "Warning  Comp. Temp. Threshold" in v:
+                higt_th = parse_value(v)
+            if not crit_th and "Critical Comp. Temp. Threshold" in v:
+                crit_th = parse_value(v)
+    return higt_th or 'N/A', crit_th or 'N/A'
+
+def initialize_ssd_thermals():
+    higt_th, crit_th = read_ssd_thresholds(SSD_DEV)
+    return [Thermal(name=f'NVME', thermal_type=ThermalType.SSD, dev=SSD_DEV, ht=higt_th, cht=crit_th)]
 
 def initialize_chassis_thermals():
-    thermal_list = []
-    for s in SENSORS:
-        if 'hwmon_path' in s:
-            set_hwmon_path(s)
-        thermal_list.append(Thermal(**s))
+    thermal_list = [Thermal(**x) for x in MLXBF_SENSORS]
+    thermal_list += initialize_sfp_thermals()
+    thermal_list += initialize_ssd_thermals()
     return thermal_list
 
 def read_fs(path, name):
@@ -72,10 +123,12 @@ def read_temp_hwmon(hwmon_path, sensor):
     return v / 1000
 
 class Thermal(ThermalBase):
-    def __init__(self, name, mlxbf_sensor_name=None, iface=None, hwmon_path=None, ht='N/A', cht='N/A'):
+    def __init__(self, name, thermal_type=None, mlxbf_sensor_name=None, dev=None, hwmon_path=None, ht='N/A', cht='N/A'):
         super(Thermal, self).__init__()
         self.name = name
+        self.thermal_type = thermal_type
         self.mlxbf_sensor_name = mlxbf_sensor_name
+        self.dev = dev
         self.hwmon_path = hwmon_path
         self.ht = ht
         self.cht = cht
@@ -97,10 +150,13 @@ class Thermal(ThermalBase):
             A float number of current temperature in Celsius up to nearest thousandth
             of one degree Celsius, e.g. 30.125
         """
-        if self.mlxbf_sensor_name:
-            return read_temp_mlxbf(self.mlxbf_sensor_name)
-        else:
-            return read_temp_hwmon(self.hwmon_path, 'temp1_input')
+        match self.thermal_type:
+            case ThermalType.MLXBF:
+                return read_temp_mlxbf(self.mlxbf_sensor_name)
+            case ThermalType.SFP:
+                return read_temp_hwmon(self.hwmon_path, 'temp1_input')
+            case ThermalType.SSD:
+                return read_ssd_temperatrue(self.dev)
 
     def get_high_threshold(self):
         """

--- a/platform/nvidia-bluefield/platform-api/tests/utils.py
+++ b/platform/nvidia-bluefield/platform-api/tests/utils.py
@@ -92,6 +92,18 @@ platform_sample_bf3 = """
 }
 """
 
+smartctl_output = """
+{
+    "smartctl_0004_u": "=== START OF INFORMATION SECTION ===",
+    "smartctl_0023_u": "Maximum Data Transfer Size:         512 Pages",
+    "smartctl_0024_u": "Warning  Comp. Temp. Threshold:     90 Celsius",
+    "smartctl_0025_u": "Critical Comp. Temp. Threshold:     100 Celsius",
+    "temperature": {
+        "current": 42
+    }
+}
+"""
+
 # Utilities for throttling tests
 class LogRecorderMock(object):
     def __init__(self):


### PR DESCRIPTION
#### Why I did it
To extend nvidia-bluefield thermal platform-api

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added support for a single-port platform
Added SSD as thermal reading

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

