### PR TITLE
[crm] add DRAM resource support to yang model and init_cfg.json

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -17,8 +17,11 @@
                     "ipmc_entry", "mpls_inseg", "mpls_nexthop"] %}
             "{{crm_res}}_threshold_type": "percentage",
             "{{crm_res}}_low_threshold": "70",
-            "{{crm_res}}_high_threshold": "85"{% if not loop.last %},{% endif -%}
-{% endfor %}
+            "{{crm_res}}_high_threshold": "85",
+{%- endfor %}
+            "dram_threshold_type": "percentage",
+            "dram_low_threshold": "90",
+            "dram_high_threshold": "95"
         }
     },
     "FLEX_COUNTER_TABLE": {

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_crm.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_crm.py
@@ -33,7 +33,8 @@ resources = [
     'mpls_inseg',
     'mpls_nexthop',
     'srv6_my_sid_entry',
-    'srv6_nexthop'
+    'srv6_nexthop',
+    'dram'
 ]
 
 

--- a/src/sonic-yang-models/yang-models/sonic-crm.yang
+++ b/src/sonic-yang-models/yang-models/sonic-crm.yang
@@ -910,6 +910,32 @@ module sonic-crm {
                     type threshold;
                 }
 
+                leaf dram_threshold_type {
+                    description "CRM threshold support for DRAM";
+
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../dram_high_threshold<100 and
+                        ../dram_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf dram_high_threshold {
+                    description "CRM threshold support for DRAM";
+
+                    must "(current() > ../dram_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf dram_low_threshold {
+                    description "CRM threshold support for DRAM";
+
+                    type threshold;
+                }
+
             }
             /* end of Config */
         }


### PR DESCRIPTION
#### Why I did it
To add support for CRM DRAM configuration

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Extended the sonic-crm.yang with CRM DRAM configuration

#### How to verify it
Run yang test_crm

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

