### PR TITLE
[Mellanox] Disable TPM on SN4280 platform

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq module_blacklist=mlx5_ib,mlx5_core"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq module_blacklist=mlx5_ib,mlx5_core modprobe.blacklist=tpm_tis,tpm_crb,tpm"


### PR DESCRIPTION
#### Why I did it
To avoid the TMP error message:
`ERR kernel: [    3.434153] tpm tpm0: [Firmware Bug]: TPM interrupt not working, polling instead`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Disable TPM via kernel option "modprobe.blacklist=tpm_tis,tpm_crb,tpm"

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

