### PR TITLE
[multi-asic] extend sonic-cfggen to add sub_role based on asic.conf

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -33,7 +33,7 @@ from config_samples import generate_sample_config, get_available_config
 from functools import partial
 from minigraph import minigraph_encoder, parse_xml, parse_device_desc_xml, parse_asic_sub_role, parse_asic_switch_type, parse_hostname
 from portconfig import get_port_config, get_breakout_mode
-from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic
+from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic, get_asic_sub_role
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
 from asic_sensors_config import get_asic_sensors_config
@@ -471,6 +471,10 @@ def main():
                 print('Warning: Failed to get device ID from asic.conf file for', asic_name, file=sys.stderr)
             else:
                 hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
+
+            sub_role = get_asic_sub_role(asic_id)
+            if sub_role is not None:
+                hardware_data['DEVICE_METADATA']['localhost'].update(sub_role=sub_role)
 
         deep_update(data, hardware_data)
 

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -152,6 +152,21 @@ def get_asic_device_id(asic_id):
 
     return None
 
+def get_asic_sub_role(asic_id):
+    asic_conf_file_path = get_asic_conf_file_path()
+    if asic_conf_file_path is None:
+        return None
+
+    with open(asic_conf_file_path) as asic_conf_file:
+        for line in asic_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+                continue
+            if tokens[0] == f"SUB_ROLE_ASIC_{asic_id}":
+                return tokens[1].strip()
+
+    return FRONTEND_ASIC_SUB_ROLE
+
 def get_current_namespace(pid=None):
     """
     This API returns the network namespace in which it is

--- a/src/sonic-py-common/tests/multi_asic_test.py
+++ b/src/sonic-py-common/tests/multi_asic_test.py
@@ -1,6 +1,25 @@
+from unittest import mock
 from sonic_py_common import multi_asic
 
 
 class TestMultiAsic:
     def test_get_container_name_from_asic_id(self):
         assert multi_asic.get_container_name_from_asic_id('database', 0) == 'database0'
+
+    def test_get_asic_sub_role(self):
+        # Mock asic.conf file
+        import textwrap
+        mock_asic_conf_content = textwrap.dedent("""
+            NUM_ASIC=3
+            DEV_ID_ASIC_0=01:00.0
+            DEV_ID_ASIC_1=02:00.0
+            DEV_ID_ASIC_2=03:00.0
+            SUB_ROLE_ASIC_0=FrontEnd
+            SUB_ROLE_ASIC_1=BackEnd
+        """)
+
+        with mock.patch('sonic_py_common.multi_asic.get_asic_conf_file_path', return_value='/mock/path/asic.conf'):
+            with mock.patch('builtins.open', mock.mock_open(read_data=mock_asic_conf_content)):
+                assert multi_asic.get_asic_sub_role(0) == 'FrontEnd'
+                assert multi_asic.get_asic_sub_role(1) == 'BackEnd'
+                assert multi_asic.get_asic_sub_role(2) == 'FrontEnd' # FrontEnd is the default sub_role


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

